### PR TITLE
Show shard popularity and sort by it

### DIFF
--- a/src/actions/shards/index.cr
+++ b/src/actions/shards/index.cr
@@ -1,5 +1,9 @@
 class Shards::Index < BrowserAction
   action do
-    render IndexPage, shards: ShardQuery.new, shard_form: ShardForm.new
+    render(
+      IndexPage,
+      shards: ShardQuery.new.popular_first,
+      shard_form: ShardForm.new
+    )
   end
 end

--- a/src/components/shards/shard_component.cr
+++ b/src/components/shards/shard_component.cr
@@ -2,6 +2,7 @@ module Shards::ShardComponent
   def render(shard : Shard)
     div class: "shard-details" do
       h3 do
+        span shard.popularity, class: "shard-popularity"
         link shard.full_name, to: Show.with(id: shard.id)
       end
       div class: "shard-details-columns" do

--- a/src/models/shard.cr
+++ b/src/models/shard.cr
@@ -10,4 +10,8 @@ class Shard < BaseModel
     field watchers_count : Int32
     field repo_created_at : Time
   end
+
+  def popularity
+    forks_count + stargazers_count + subscribers_count + watchers_count
+  end
 end

--- a/src/queries/shard_query.cr
+++ b/src/queries/shard_query.cr
@@ -1,8 +1,12 @@
 class ShardQuery < Shard::BaseQuery
   def popular_first
-    order_by(
-      "forks_count + stargazers_count + subscribers_count + watchers_count",
-      :desc
-    )
+    table = ShardForm.new.table_name
+    query = [
+      forks_count.column,
+      "#{table}.#{stargazers_count.column}",
+      "#{table}.#{subscribers_count.column}",
+      "#{table}.#{watchers_count.column}"
+    ].join(" + ")
+    order_by(query, :desc)
   end
 end

--- a/src/queries/shard_query.cr
+++ b/src/queries/shard_query.cr
@@ -1,2 +1,8 @@
 class ShardQuery < Shard::BaseQuery
+  def popular_first
+    order_by(
+      "forks_count + stargazers_count + subscribers_count + watchers_count",
+      :desc
+    )
+  end
 end

--- a/static/css/components/shard-details.pcss
+++ b/static/css/components/shard-details.pcss
@@ -1,6 +1,13 @@
 .shard-details {
 }
 
+.shard-popularity {
+  background-color: $color-grey-light;
+  border-radius: .5em;
+  margin-right: .5em;
+  padding: .2em .5em;
+}
+
 .shard-details-columns {
   align-items: flex-start;
   display: flex;


### PR DESCRIPTION
![screen shot 2018-01-24 at 12 10 40 pm](https://user-images.githubusercontent.com/49549/35346216-a324ac06-00ff-11e8-9748-ee089e68dfbb.png)

This is a pretty simple algorithm and display. The algorithm (such as it is) is only forks + stars + subscribers + watchers. Then I added the badge showing the popularity next to the shard name.

Critique welcome.

fixes #2 