### PR TITLE
Add category model and seeds

### DIFF
--- a/db/migrations/20180131140018_add_categories.cr
+++ b/db/migrations/20180131140018_add_categories.cr
@@ -1,0 +1,11 @@
+class AddCategories::V20180131140018 < LuckyMigrator::Migration::V1
+  def migrate
+    create :categories do
+     add title : String
+    end
+  end
+
+  def rollback
+    drop :categories
+  end
+end

--- a/db/migrations/20180201101538_add_category_to_shard.cr
+++ b/db/migrations/20180201101538_add_category_to_shard.cr
@@ -1,0 +1,21 @@
+class AddCategoryToShard::V20180201101538 < LuckyMigrator::Migration::V1
+  def migrate
+    alter :shards do
+      add category_id : Int32?
+    end
+
+    execute <<-SQL
+      ALTER TABLE shards
+      ADD CONSTRAINT shards_category_id_fk
+      FOREIGN KEY (category_id)
+      REFERENCES categories (id)
+      ON DELETE RESTRICT;
+    SQL
+  end
+
+  def rollback
+    alter :shards do
+      remove :category_id
+    end
+  end
+end

--- a/src/components/shards/shard_creation_form.cr
+++ b/src/components/shards/shard_creation_form.cr
@@ -12,7 +12,7 @@ module Shards::ShardCreationForm
   end
 
   private def categories_for_select
-    CategoryQuery.new.map do |category|
+    CategoryQuery.new.title.asc_order.map do |category|
       {category.title, category.id}
     end
   end

--- a/src/components/shards/shard_creation_form.cr
+++ b/src/components/shards/shard_creation_form.cr
@@ -1,0 +1,19 @@
+module Shards::ShardCreationForm
+  def render_shard_form(form : ShardForm)
+    form_for Create do
+      text_input form.repo_name, placeholder: "user/repo_name"
+      errors_for form.repo_name
+      select_input form.category_id do
+        options_for_select(form.category_id, categories_for_select)
+      end
+
+      submit "Add"
+    end
+  end
+
+  private def categories_for_select
+    CategoryQuery.new.map do |category|
+      {category.title, category.id}
+    end
+  end
+end

--- a/src/components/shards/shard_creation_form.cr
+++ b/src/components/shards/shard_creation_form.cr
@@ -1,5 +1,5 @@
 module Shards::ShardCreationForm
-  def render_shard_form(form : ShardForm)
+  def render(form : ShardForm)
     form_for Create do
       text_input form.repo_name, placeholder: "user/repo_name"
       errors_for form.repo_name

--- a/src/forms/category_form.cr
+++ b/src/forms/category_form.cr
@@ -1,0 +1,3 @@
+class CategoryForm < Category::BaseForm
+  allow title
+end

--- a/src/forms/category_form.cr
+++ b/src/forms/category_form.cr
@@ -6,7 +6,7 @@ class CategoryForm < Category::BaseForm
   end
 
   def validate_uniqueness_of_title
-    if CategoryQuery.new.title.lower.is(title.value.to_s.downcase).size > 0
+    if CategoryQuery.new.title.lower.is(title.value.to_s.downcase).any?
       title.add_error "already exists"
     end
   end

--- a/src/forms/category_form.cr
+++ b/src/forms/category_form.cr
@@ -1,3 +1,13 @@
 class CategoryForm < Category::BaseForm
   allow title
+
+  def prepare
+    validate_uniqueness_of_title
+  end
+
+  def validate_uniqueness_of_title
+    if CategoryQuery.new.title.lower.is(title.value.to_s.downcase).size > 0
+      title.add_error "already exists"
+    end
+  end
 end

--- a/src/forms/shard_form.cr
+++ b/src/forms/shard_form.cr
@@ -1,4 +1,5 @@
 class ShardForm < Shard::BaseForm
+  allow category_id
   allow_virtual repo_name : String
 
   def prepare

--- a/src/models/category.cr
+++ b/src/models/category.cr
@@ -1,0 +1,5 @@
+class Category < BaseModel
+  table :categories do
+    field title : String
+  end
+end

--- a/src/models/shard.cr
+++ b/src/models/shard.cr
@@ -9,6 +9,7 @@ class Shard < BaseModel
     field subscribers_count : Int32
     field watchers_count : Int32
     field repo_created_at : Time
+    belongs_to category : Category?
   end
 
   def popularity

--- a/src/pages/shards/index_page.cr
+++ b/src/pages/shards/index_page.cr
@@ -25,8 +25,17 @@ class Shards::IndexPage < MainLayout
   private def render(f : ShardForm)
     form_for Create do
       text_input f.repo_name, placeholder: "user/repo_name"
+      select_input f.category_id do
+        options_for_select(f.category_id, categories_for_select)
+      end
 
       submit "Add"
+    end
+  end
+
+  private def categories_for_select
+    CategoryQuery.new.map do |category|
+      {category.title, category.id}
     end
   end
 end

--- a/src/pages/shards/index_page.cr
+++ b/src/pages/shards/index_page.cr
@@ -22,8 +22,4 @@ class Shards::IndexPage < MainLayout
       render(shard)
     end
   end
-
-  private def render(f : ShardForm)
-    render_shard_form(f)
-  end
 end

--- a/src/pages/shards/index_page.cr
+++ b/src/pages/shards/index_page.cr
@@ -1,5 +1,6 @@
 class Shards::IndexPage < MainLayout
   include Shards::ShardComponent
+  include Shards::ShardCreationForm
 
   needs shards : ShardQuery
   needs shard_form : ShardForm
@@ -23,19 +24,6 @@ class Shards::IndexPage < MainLayout
   end
 
   private def render(f : ShardForm)
-    form_for Create do
-      text_input f.repo_name, placeholder: "user/repo_name"
-      select_input f.category_id do
-        options_for_select(f.category_id, categories_for_select)
-      end
-
-      submit "Add"
-    end
-  end
-
-  private def categories_for_select
-    CategoryQuery.new.map do |category|
-      {category.title, category.id}
-    end
+    render_shard_form(f)
   end
 end

--- a/src/pages/shards/new_page.cr
+++ b/src/pages/shards/new_page.cr
@@ -11,8 +11,17 @@ class Shards::NewPage < MainLayout
     form_for Create do
       text_input f.repo_name
       errors_for f.repo_name
+      select_input f.category_id do
+        options_for_select(f.category_id, categories_for_select)
+      end
 
       submit "Add"
+    end
+  end
+
+  private def categories_for_select
+    CategoryQuery.new.map do |category|
+      {category.title, category.id}
     end
   end
 end

--- a/src/pages/shards/new_page.cr
+++ b/src/pages/shards/new_page.cr
@@ -7,8 +7,4 @@ class Shards::NewPage < MainLayout
 
     render @shard_form
   end
-
-  private def render(f : ShardForm)
-    render_shard_form(f)
-  end
 end

--- a/src/pages/shards/new_page.cr
+++ b/src/pages/shards/new_page.cr
@@ -1,4 +1,5 @@
 class Shards::NewPage < MainLayout
+  include Shards::ShardCreationForm
   needs shard_form : ShardForm
 
   def inner
@@ -8,20 +9,6 @@ class Shards::NewPage < MainLayout
   end
 
   private def render(f : ShardForm)
-    form_for Create do
-      text_input f.repo_name
-      errors_for f.repo_name
-      select_input f.category_id do
-        options_for_select(f.category_id, categories_for_select)
-      end
-
-      submit "Add"
-    end
-  end
-
-  private def categories_for_select
-    CategoryQuery.new.map do |category|
-      {category.title, category.id}
-    end
+    render_shard_form(f)
   end
 end

--- a/src/queries/category_query.cr
+++ b/src/queries/category_query.cr
@@ -1,0 +1,2 @@
+class CategoryQuery < Category::BaseQuery
+end

--- a/tasks/seed/categories.cr
+++ b/tasks/seed/categories.cr
@@ -1,0 +1,24 @@
+require "yaml"
+
+class Seed::Categories < LuckyCli::Task
+  banner "Seed the app with some initial categories"
+
+  def call
+    yaml = File.read("tasks/seed/categories.yml")
+    categories = YAML.parse(yaml)
+
+    categories.each do |title|
+      params = LuckyRecord::Params.new({"title" => title.as_s})
+      CategoryForm.create(params) do |form, category|
+        if category
+          puts "Created Category: #{category.title.colorize(:green)}"
+        else
+          puts "Problem creating category:"
+          form.errors.each do |field, errors|
+            puts "#{field} #{title.colorize(:red)} #{errors.join(", ")}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/tasks/seed/categories.yml
+++ b/tasks/seed/categories.yml
@@ -1,4 +1,4 @@
-- Algorithms and Data structures
+- Algorithms and Data Structures
 - API Builders
 - Caching
 - CLI Builders
@@ -10,8 +10,8 @@
 - Feature Gate
 - Framework Components
 - Game Development
-- GUI library
-- HTML/XML parsing
+- GUI Library
+- HTML/XML Parsing
 - HTTP
 - Image Processing
 - Logging/Monitoring
@@ -26,9 +26,9 @@
 - Queue
 - Routing
 - Scheduling
-- Science and Data analysis
+- Science and Data Analysis
 - Search
-- Task management
+- Task Management
 - Template Engine
 - Testing
 - Virtualization

--- a/tasks/seed/categories.yml
+++ b/tasks/seed/categories.yml
@@ -1,0 +1,36 @@
+- Algorithms and Data structures
+- API Builders
+- Caching
+- CLI Builders
+- Configuration
+- Data Generators
+- Database Drivers
+- Email
+- Environment Management
+- Feature Gate
+- Framework Components
+- Game Development
+- GUI library
+- HTML/XML parsing
+- HTTP
+- Image Processing
+- Logging/Monitoring
+- Machine Learning
+- Markdown/Text Processors
+- Networking
+- ORM/ODM Extensions
+- Other Languages
+- Package Management
+- Processes and Threads
+- Project Generators
+- Queue
+- Routing
+- Scheduling
+- Science and Data analysis
+- Search
+- Task management
+- Template Engine
+- Testing
+- Virtualization
+- Web Frameworks
+- Web Server


### PR DESCRIPTION
A Category simply has a title. I chose "title" instead of "name" because the difference between the two can be very ambiguous. I tend to reserve "name" for if the thing I'm representing has a personality. Think Person, User, Pet, AutonomousCompanion. Everything else should have a title. The exception is if there's some preexisting model you need to adhere to that uses name.

For the actual seed categories, I made some modifications from the Awesome Crystal list. I didn't want categories that were not comparable. For example, you're probably not comparing third party APIs against each other as how popular the Github shard is has no effect on the Amazon S3 shard.

Finally, each category must have a unique name, enforced by a uniqueness validation in the Category form.

Fixes #4