### PR TITLE
Make a shard's description nillable

### DIFF
--- a/db/migrations/20180202164331_make_shard_description_nillable.cr
+++ b/db/migrations/20180202164331_make_shard_description_nillable.cr
@@ -1,0 +1,13 @@
+class MakeShardDescriptionNillable::V20180202164331 < LuckyMigrator::Migration::V1
+  def migrate
+    execute <<-SQL
+      ALTER TABLE shards
+      ALTER COLUMN description DROP NOT NULL;
+    SQL
+  end
+
+  def rollback
+    execute "ALTER TABLE shards ALTER COLUMN description SET DEFAULT '';"
+    execute "ALTER TABLE shards ALTER COLUMN description SET NOT NULL;"
+  end
+end

--- a/src/clients/github/repo.cr
+++ b/src/clients/github/repo.cr
@@ -3,7 +3,7 @@ class Github::Repo
     name: String,
     full_name: String,
     html_url: String,
-    description: String,
+    description: String?,
     forks_count: Int32,
     stargazers_count: Int32,
     subscribers_count: Int32,

--- a/src/components/shards/shard_component.cr
+++ b/src/components/shards/shard_component.cr
@@ -9,7 +9,7 @@ module Shards::ShardComponent
         div class: "shard-details-description" do
           para "Created #{shard.repo_created_at.to_s("%-d %B %Y")}"
           em do
-            para shard.description
+            para shard.description || ""
           end
         end
         div class: "shard-details-metadata" do

--- a/src/models/shard.cr
+++ b/src/models/shard.cr
@@ -3,7 +3,7 @@ class Shard < BaseModel
     field name : String
     field full_name : String
     field html_url : String
-    field description : String
+    field description : String?
     field forks_count : Int32
     field stargazers_count : Int32
     field subscribers_count : Int32


### PR DESCRIPTION
We grab the description from the GitHub repo, and it might not be set.

The migration simply removes the NULL constraint on the database. The
reverse migration sets the default to be an empty string, then re-adds
the NULL constraint.

I needed to change the type for description from `String` to `String?`
and finally, ensure that if there is no description the ShowPage
doesn't crash.

Fixes #17 