### PR TITLE
Add .local to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ yarn-error.log
 server
 *.dwarf
 bin/lucky/
+.local


### PR DESCRIPTION
I like to have a space where I can put temporary files or personal files relating to a project, but that don't need to be committed. Screenshots, notes, etc.

I use a .local directory for this, but I'm all ears for other names or ways to accomplish the same thing.